### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -318,7 +318,7 @@ export async function getGoogleCredentials(
 ): Promise<GoogleCredentials> {
   try {
     console.log('Secrets ManagerからGoogle認証情報を取得中...');
-    console.log('使用するシークレットID:', secretId);
+    // セキュリティ上の理由で、シークレットIDはログに出力しません
     
     const command = new GetSecretValueCommand({
       SecretId: secretId


### PR DESCRIPTION
Potential fix for [https://github.com/naotty/receipt-bot/security/code-scanning/1](https://github.com/naotty/receipt-bot/security/code-scanning/1)

To fix the problem, we should avoid logging the value of `secretId` in clear text. Instead, we can log a generic message indicating that the credentials are being retrieved, without including the actual secret identifier. The change should be made in the `getGoogleCredentials` function in the `index.ts` file, specifically on line 321. Remove or rewrite the log statement so it does not display the secretId value. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
